### PR TITLE
Dockerfile:  add dnf-utils

### DIFF
--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.fedoraproject.org/fedora:28
 # We install fedpkg specifically because while it's optional, pretty much everyone
 # will want it.
-RUN dnf -y install autoconf automake fedpkg gcc git libtool make python2-pyyaml python3-PyYAML which && \
+RUN dnf -y install autoconf automake dnf-utils fedpkg gcc git libtool make python2-pyyaml python3-PyYAML which && \
     dnf clean all && \
     adduser unprivileged && \
     usermod -a -G mock unprivileged && \


### PR DESCRIPTION
Using the updated instructions for building an `rdgo` container image
via `podman`, I was unable to actually build RPMs with the resulting
container due to missing `yum-builddep`.  Adding the `dnf-utils` to
the image resolved the problem.