### PR TITLE
Add a `build-network: True` manifest option

### DIFF
--- a/doc/example-overlay.yml
+++ b/doc/example-overlay.yml
@@ -48,6 +48,8 @@ components:
       name: golang-github-shurcooL-sanitized_anchor_name
 
   - src: github:projectatomic/rpm-ostree
+    # Enable networking at build time (breaks reproducibility)
+    build-network: true
     distgit:
       # You can drop patches from dist-git in case they're already
       # merged in upstream git master.

--- a/rdgo/basetask_resolve.py
+++ b/rdgo/basetask_resolve.py
@@ -81,7 +81,8 @@ class BaseTaskResolve(Task):
     def _expand_component(self, component):
         for key in component:
             if key not in ['src', 'spec', 'distgit', 'tag', 'branch', 'freeze', 'self-buildrequires',
-                           'rpmwith', 'rpmwithout', 'srpmroot', 'override-version', 'defines']:
+                           'rpmwith', 'rpmwithout', 'srpmroot', 'override-version', 'defines',
+                           'build-network']:
                 fatal("Unknown key {0} in component: {1}".format(key, component))
         # 'src' and 'distgit' mappings
         src = component.get('src')

--- a/rdgo/mockchain.py
+++ b/rdgo/mockchain.py
@@ -49,7 +49,7 @@ MOCKCONFDIR = os.path.join(SYSCONFDIR, "mock")
 # This variable is global as it's set by `eval`ing the mock config file =(
 config_opts = {}
 
-SRPMBuild = collections.namedtuple('SRPMBuild', ['filename', 'rpmwith', 'rpmwithout', 'rpmbuildopts'])
+SRPMBuild = collections.namedtuple('SRPMBuild', ['filename', 'rpmwith', 'rpmwithout', 'rpmbuildopts', 'networking'])
 
 def log(msg):
     print(msg)
@@ -264,6 +264,8 @@ class MockChain(object):
             mockcmd.append('--with=' + rpmwith)
         for rpmwithout in pkg.rpmwithout:
             mockcmd.append('--without=' + rpmwithout)
+        if pkg.networking:
+            mockcmd.append('--enable-network')
         mockcmd.append(srpm)
         print('Executing: {0}'.format(subprocess.list2cmdline(mockcmd)))
         cmd = subprocess.Popen(mockcmd)
@@ -281,7 +283,7 @@ class MockChain(object):
         _pkgs = []
         for pkg in pkgs:
             if not isinstance(pkg, SRPMBuild):
-                pkg = SRPMBuild(pkg, [], [])
+                pkg = SRPMBuild(pkg, [], [], False)
             _pkgs.append(pkg)
         pkgs = _pkgs
         for pkg in pkgs:

--- a/rdgo/task_build.py
+++ b/rdgo/task_build.py
@@ -190,7 +190,10 @@ class TaskBuild(Task):
             newcache[distgit_name] = {'hashv0': component_hash,
                                       'dirname': srcsnap.replace('.srcsnap','')}
             needed_builds.append((component, SRPMBuild(self.snapshotdir + '/' + srcsnap + '/',
-                                                       component['rpmwith'], component['rpmwithout'], component['rpmbuildopts'])))
+                                                       component['rpmwith'],
+                                                       component['rpmwithout'],
+                                                       component['rpmbuildopts'],
+                                                       component.get('build-network', False))))
             need_createrepo = True
 
         # At this point we've consumed any previous partial results, so clean up the dir.


### PR DESCRIPTION
Related: https://github.com/projectatomic/rpmdistro-gitoverlay/issues/48

This is an easy hack; I'm broadly speaking OK with relying on crates.io
for rpm-ostree's CI builds for now.  If we take over and replace
the Koji stack, we can look at fixing the above issue.